### PR TITLE
Re-enabled unprotect reviews

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           token: ${{ secrets.PAT }}
           branch: main
-          unprotect_reviews: false
+          unprotect_reviews: true
           timeout: 30
           sleep: 30
 


### PR DESCRIPTION
# Description

Re-enabling unprotect reviews in project to properly unprotect reviews when pushing semantic version changes.

# How Has This Been Tested?

tested both ways and ensures it works properly only with unprotect reviews enabled.

