### PR TITLE
Added Changelog to Documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,11 +93,12 @@ crashlytics-build.properties
 /ProjectSettings/Packages
 
 # Documentation
+Assets/**/obj*
+_site/
 Documentation/api/
-Documentation/index.*
+Documentation/Changelog/CHANGELOG.md
 Documentation/Demo/
+Documentation/index.*
 Documentation/LICENSE.txt
 Documentation/obj/
-_site/
-Assets/**/obj*
 Packages/**/obj*

--- a/Documentation/build.cmd
+++ b/Documentation/build.cmd
@@ -2,6 +2,7 @@
 echo Setting up website and copying files
 copy %~dp0\..\README.md %~dp0\index.md
 copy %~dp0\..\LICENSE.txt %~dp0\LICENSE.txt
+copy %~dp0\..\Packages\com.nickmaltbie.screenmanager\CHANGELOG.md %~dp0\changelog\CHANGELOG.md
 xcopy /E /S /Y %~dp0\..\Demo %~dp0\Demo\
 
 @REM Generate website with docfx

--- a/Documentation/build.sh
+++ b/Documentation/build.sh
@@ -4,6 +4,7 @@ BASEDIR=$(dirname "$0")
 echo "Setting up website and copying files"
 cp $BASEDIR/../README.md $BASEDIR/index.md
 cp $BASEDIR/../LICENSE.txt $BASEDIR/LICENSE.txt
+cp $BASEDIR/../Packages/com.nickmaltbie.screenmanager/CHANGELOG.md $BASEDIR/CHANGELOG.md
 cp -r $BASEDIR/../Demo $BASEDIR/Demo
 
 # Generate website with docfx

--- a/Documentation/changelog/toc.yml
+++ b/Documentation/changelog/toc.yml
@@ -1,0 +1,5 @@
+# Changelog is populated from Packages\com.nickmaltbie.screenmanager\CHANGELOG.md
+# as part of build script.
+
+- name: Changelog
+  href: CHANGELOG.md

--- a/Documentation/docfx.json
+++ b/Documentation/docfx.json
@@ -42,6 +42,15 @@
                     "*.md"
                 ],
                 "dest": "manual"
+            },
+            {
+                "src": "changelog",
+                "files":
+                [
+                    "toc.yml",
+                    "*.md"
+                ],
+                "dest": "changelog"
             }
         ],
         "overwrite": [
@@ -50,6 +59,9 @@
                 "files": [
                     "ScreenManager/**/*.md",
                     "Tests/**/*.md"
+                ],
+                "exclude": [
+                    "**/CHANGELOG.md"
                 ]
             }
         ],

--- a/Documentation/toc.yml
+++ b/Documentation/toc.yml
@@ -2,3 +2,5 @@
   href: manual/
 - name: Scripting API
   href: api/
+- name: Changelog
+  href: changelog/

--- a/Packages/com.nickmaltbie.screenmanager/CHANGELOG.md
+++ b/Packages/com.nickmaltbie.screenmanager/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 Minor changes to documentation
 * Included information on how to reference a specific tag of the project
     when importing the library.
+* Added changelog to auto-generated doc fx website.
 
 Minor Bugfixes
 * Corrected some import errors when project is imported


### PR DESCRIPTION
# Description

Adjusted documentation build to include changelog from the packages folder.

Now whenever the documentation is built, it will include the project changelog in the build as well.

# How Has This Been Tested?

This has been tested locally in the docfx build and added to the automated build scripts.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that demonstrate the new feature or bugfix
- [x] New and existing unit and integrations tests pass locally with my changes
