### PR TITLE
Removed Package Type from Manifest

### DIFF
--- a/Packages/com.nickmaltbie.screenmanager/package.json
+++ b/Packages/com.nickmaltbie.screenmanager/package.json
@@ -15,7 +15,6 @@
     "ui",
     "screen"
   ],
-  "type": "library",
   "samples": [
     {
       "displayName": "Rebinding Example",


### PR DESCRIPTION
# Description

Removed package type from project manifest, it's reserved type for unity so package shouldn't include it.
